### PR TITLE
Suppression du _yield() dans le timer.

### DIFF
--- a/Logiciel/remora/pilotes.cpp
+++ b/Logiciel/remora/pilotes.cpp
@@ -275,8 +275,6 @@ void updateFPCounter(_timer_callback_arg)
         break;
     }
   }
-
-  _yield();
 }
 
 /* ======================================================================


### PR DESCRIPTION
Provoque des interblocages sur particle pour cause d'appel concurrent de Particle.process().
